### PR TITLE
fix: restore Bun detection/support on top of #9262

### DIFF
--- a/packages/app-builder-lib/src/node-module-collector/index.ts
+++ b/packages/app-builder-lib/src/node-module-collector/index.ts
@@ -16,6 +16,9 @@ export async function getCollectorByPackageManager(pm: PM, rootDir: string, temp
       return new NpmNodeModulesCollector(rootDir, tempDirManager)
     case PM.YARN:
       return new YarnNodeModulesCollector(rootDir, tempDirManager)
+    case PM.BUN:
+      // Bun installs deps, but we use npm to query rich dependency graph
+      return new NpmNodeModulesCollector(rootDir, tempDirManager)
     default:
       return new NpmNodeModulesCollector(rootDir, tempDirManager)
   }


### PR DESCRIPTION
This builds on #9262 and restores Bun support:\n- Add PM.BUN\n- Detect Bun via UA/exec path/packageManager/env (BUN_INSTALL)/runtime (process.versions.bun)\n- Detect bun.lockb in lockfile scan\n- Route Bun to NpmNodeModulesCollector for dependency graph JSON\n\nThis addresses Bun builds being mis-detected as Yarn and should be safe alongside the Yarn Berry improvements.