### PR TITLE
fix: select matching pnpm dependency tree

### DIFF
--- a/.changeset/all-dancers-yell.md
+++ b/.changeset/all-dancers-yell.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: select matching pnpm dependency tree for workspace packages

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -51,7 +51,7 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
     nodeModules: NodeModuleInfo[]
     logSummary: ModuleManager["logSummary"]
   }> {
-    const tree: ProdDepType = await this.getDependenciesTree(this.installOptions.manager)
+    const tree: ProdDepType = await this.getDependenciesTree(this.installOptions.manager, packageName)
 
     await this.collectAllDependencies(tree, packageName)
     const realTree: ProdDepType = this.getTreeFromWorkspaces(tree, packageName)
@@ -84,7 +84,7 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
    * the output to a temporary file. Includes retry logic to handle transient failures such as
    * incomplete JSON output or missing files. Will retry up to 1 time with exponential backoff.
    */
-  protected async getDependenciesTree(pm: PM): Promise<ProdDepType> {
+  protected async getDependenciesTree(pm: PM, packageName?: string): Promise<ProdDepType> {
     const command = getPackageManagerCommand(pm)
     const args = this.getArgs()
 
@@ -97,7 +97,7 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
       async () => {
         await this.streamCollectorCommandToFile(command, args, this.rootDir, tempOutputFile)
         const shellOutput = await fs.readFile(tempOutputFile, { encoding: "utf8" })
-        const result = await Promise.resolve(this.parseDependenciesTree(shellOutput))
+        const result = await Promise.resolve(this.parseDependenciesTree(shellOutput, packageName))
         return result
       },
       {
@@ -146,7 +146,7 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
    * Parses the dependencies tree from shell command output.
    *
    **/
-  protected parseDependenciesTree(shellOutput: string): ProdDepType | Promise<ProdDepType> {
+  protected parseDependenciesTree(shellOutput: string, _packageName?: string): ProdDepType | Promise<ProdDepType> {
     return this.extractJsonFromPollutedOutput<ProdDepType>(shellOutput)
   }
 

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -102,9 +102,20 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
     }
   }
 
-  protected parseDependenciesTree(jsonBlob: string): PnpmDependency {
+  protected parseDependenciesTree(jsonBlob: string, packageName?: string): PnpmDependency {
     // pnpm returns an array of dependency trees
     const dependencyTree: PnpmDependency[] = this.extractJsonFromPollutedOutput<PnpmDependency[]>(jsonBlob)
+    if (dependencyTree.length === 0) {
+      throw new Error("pnpm list returned no dependency trees")
+    }
+
+    if (packageName) {
+      const matchedTree = dependencyTree.find(tree => tree.name === packageName)
+      if (matchedTree) {
+        return matchedTree
+      }
+    }
+
     return dependencyTree[0]
   }
 }

--- a/test/src/parseNameVersionTest.ts
+++ b/test/src/parseNameVersionTest.ts
@@ -1,11 +1,23 @@
-import { PnpmNodeModulesCollector } from "app-builder-lib/out/node-module-collector/pnpmNodeModulesCollector"
+import { PnpmNodeModulesCollector } from "app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector"
 import { TmpDir } from "temp-file"
 import { describe, expect, test } from "vitest"
 
+type TestablePnpmNodeModulesCollector = {
+  parseNameVersion(identifier: string): { name: string; version: string }
+  parseDependenciesTree(dependencyTree: string, packageName?: string): { name: string; version: string; path: string }
+}
+
+function createTestableCollector(): TestablePnpmNodeModulesCollector {
+  return new PnpmNodeModulesCollector(".", new TmpDir("test")) as unknown as TestablePnpmNodeModulesCollector
+}
+
 // Access protected method via cast for unit testing
 function parseNameVersion(identifier: string): { name: string; version: string } {
-  const collector = new (PnpmNodeModulesCollector as any)(".", new TmpDir("test"))
-  return (collector as any).parseNameVersion(identifier)
+  return createTestableCollector().parseNameVersion(identifier)
+}
+
+function parsePnpmDependenciesTree(dependencyTree: Array<{ name: string; version: string; path: string }>, packageName?: string) {
+  return createTestableCollector().parseDependenciesTree(JSON.stringify(dependencyTree), packageName)
 }
 
 describe("parseNameVersion", () => {
@@ -56,5 +68,28 @@ describe("parseNameVersion", () => {
 
   test("scoped package with workspace: protocol", () => {
     expect(parseNameVersion("@myorg/core@workspace:*")).toEqual({ name: "@myorg/core", version: "workspace:*" })
+  })
+})
+
+describe("PnpmNodeModulesCollector.parseDependenciesTree", () => {
+  const dependencyTree = [
+    { name: "workspace-root", version: "1.0.0", path: "/workspace" },
+    { name: "test-app", version: "1.0.0", path: "/workspace/packages/test-app" },
+  ]
+
+  test("returns dependency tree matching package name", () => {
+    expect(parsePnpmDependenciesTree(dependencyTree, "test-app")).toEqual(dependencyTree[1])
+  })
+
+  test("returns first dependency tree when package name is omitted", () => {
+    expect(parsePnpmDependenciesTree(dependencyTree)).toEqual(dependencyTree[0])
+  })
+
+  test("falls back to first dependency tree when package name does not match", () => {
+    expect(parsePnpmDependenciesTree(dependencyTree, "unknown-app")).toEqual(dependencyTree[0])
+  })
+
+  test("throws when pnpm returns no dependency trees", () => {
+    expect(() => parsePnpmDependenciesTree([])).toThrow("pnpm list returned no dependency trees")
   })
 })


### PR DESCRIPTION
## Summary
- pass the app package name into dependency tree parsing
- select the pnpm dependency tree whose name matches package.json before falling back to the first tree
- add unit coverage for matching, fallback, omitted package name, and empty pnpm output

## Tests
- TEST_FILES=parseNameVersionTest pnpm ci:test
- pnpm exec eslint packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts test/src/parseNameVersionTest.ts
- git diff --check

Note: pnpm compile currently fails in this local checkout due unrelated missing modules/outputs: extract-zip, @electron/get, and app-builder-lib/out/util/electronGet.